### PR TITLE
Blink Features report

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Tag: `blink_features_report`
 
 Consumers:
 
-- [chromestatus.com](https://chromestatus.com/metrics/feature/timeline/popularity/2089)
+- chromestatus.com - [example](https://chromestatus.com/metrics/feature/timeline/popularity/2089)
 
 ### Legacy crawl results (to be deprecated)
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,57 @@
 # HTTP Archive BigQuery pipeline with Dataform
 
-## Tables
+## Datasets
 
-### Crawl tables in `all` dataset
+### Crawl results
 
 Tag: `crawl_results_all`
 
-- [x] httparchive.all.pages
-- [x] httparchive.all.parsed_css
-- [x] httparchive.all.requests
+- httparchive.all.pages
+- httparchive.all.parsed_css
+- httparchive.all.requests
 
 ### Core Web Vitals Technology Report
 
 Tag: `cwv_tech_report`
 
-- [x] httparchive.core_web_vitals.technologies
+- httparchive.core_web_vitals.technologies
 
-### Legacy crawl tables (to be deprecated)
+Consumers:
+
+- [HTTP Archive Tech Report](https://httparchive.org/reports/techreport/landing)
+
+### Blink Features Report
+
+Tag: `blink_features_report`
+
+- httparchive.blink_features.features
+- httparchive.blink_features.usage
+
+Consumers:
+
+- [chromestatus.com](https://chromestatus.com/metrics/feature/timeline/popularity/2089)
+
+### Legacy crawl results (to be deprecated)
 
 Tag: `crawl_results_legacy`
 
-- [x] httparchive.lighthouse.YYYY_MM_DD_client
-- [x] httparchive.pages.YYYY_MM_DD_client
-- [x] httparchive.requests.YYYY_MM_DD_client
-- [x] httparchive.response_bodies.YYYY_MM_DD_client
-- [x] httparchive.summary_pages.YYYY_MM_DD_client
-- [x] httparchive.summary_requests.YYYY_MM_DD_client
-- [x] httparchive.technologies.YYYY_MM_DD_client
+- httparchive.lighthouse.YYYY_MM_DD_client
+- httparchive.pages.YYYY_MM_DD_client
+- httparchive.requests.YYYY_MM_DD_client
+- httparchive.response_bodies.YYYY_MM_DD_client
+- httparchive.summary_pages.YYYY_MM_DD_client
+- httparchive.summary_requests.YYYY_MM_DD_client
+- httparchive.technologies.YYYY_MM_DD_client
 
 ## Schedules
 
 1. [crawl-complete](https://console.cloud.google.com/cloudpubsub/subscription/detail/dataformTrigger?authuser=7&project=httparchive) PubSub subscription
 
-    Tags:
-
-   - crawl_results_all
-   - crawl_results_legacy
+    Tags: ["crawl_results_all", "blink_features_report", "crawl_results_legacy"]
 
 2. [bq-poller-cwv-tech-report](https://console.cloud.google.com/cloudscheduler/jobs/edit/us-east4/bq-poller-cwv-tech-report?authuser=7&project=httparchive) Scheduler
 
-    Tags:
-
-    - cwv_tech_report
+    Tags: ["cwv_tech_report"]
 
 ### Triggering workflows
 
@@ -58,5 +68,5 @@ Tag: `crawl_results_legacy`
 ### Dataform development workspace hints
 
 1. In workflow settings vars set `dev_name: dev` to process sampled data in dev workspace.
-2. Change `current_month` variable to a month in the past. May be helpful for testing pipelines based on `chrome-ux-report` data.
+2. Change `today` variable to a date in the past. May be helpful for testing pipelines based on `chrome-ux-report` data.
 3. `definitions/extra/test_env.sqlx` script helps to setup the tables required to run pipelines when in dev workspace. It's disabled by default.

--- a/definitions/extra/test_env.js
+++ b/definitions/extra/test_env.js
@@ -6,19 +6,19 @@ operate("test_env", {
 }).queries(ctx => `
 CREATE SCHEMA IF NOT EXISTS all_dev;
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "pages")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("all", "pages")} AS
 SELECT *
 FROM httparchive.all.pages
 WHERE
   date = '${constants.current_month}'
   ${constants.dev_rank5000_filter};
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "requests")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("all", "requests")} AS
 SELECT *
 FROM httparchive.all.requests ${constants.dev_TABLESAMPLE}
 WHERE date = '${constants.current_month}';
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "parsed_css")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("all", "parsed_css")} AS
 SELECT *
 FROM httparchive.all.parsed_css
 WHERE date = '${constants.current_month}'
@@ -26,19 +26,19 @@ WHERE date = '${constants.current_month}'
 
 CREATE SCHEMA IF NOT EXISTS core_web_vitals_dev;
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("core_web_vitals", "technologies")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("core_web_vitals", "technologies")} AS
 SELECT *
 FROM httparchive.core_web_vitals.technologies ${constants.dev_TABLESAMPLE}
 WHERE date = '${past_month}';
 
 CREATE SCHEMA IF NOT EXISTS blink_features_dev;
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("blink_features", "usage")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("blink_features", "usage")} AS
 SELECT *
 FROM httparchive.blink_features.usage ${constants.dev_TABLESAMPLE}
 WHERE yyyymmdd = '${past_month}';
 
-CREATE TABLE IF NOT EXISTS ${ctx.ref("blink_features", "features")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.resolve("blink_features", "features")} AS
 SELECT *
 FROM httparchive.blink_features.features ${constants.dev_TABLESAMPLE}
 WHERE yyyymmdd = DATE '${past_month}';

--- a/definitions/extra/test_env.js
+++ b/definitions/extra/test_env.js
@@ -1,26 +1,45 @@
-const two_months_ago = constants.fn_past_month(constants.fn_past_month(constants.current_month));
+const past_month = constants.fn_past_month(constants.current_month);
 
 operate("test_env", {
   hasOutput: true,
-  disabled: true // MUST NOT be commented in main branch
+  disabled: true // MUST be disabled in main branch
 }).queries(ctx => `
-CREATE OR REPLACE TABLE ${ctx.ref("all", "pages")} AS
-SELECT *
-FROM httparchive.all.pages ${constants.dev_TABLESAMPLE}
-WHERE date = '${two_months_ago}';
+CREATE SCHEMA IF NOT EXISTS all_dev;
 
-CREATE OR REPLACE TABLE ${ctx.ref("all", "requests")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "pages")} AS
+SELECT *
+FROM httparchive.all.pages
+WHERE
+  date = '${constants.current_month}'
+  ${constants.dev_rank5000_filter};
+
+CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "requests")} AS
 SELECT *
 FROM httparchive.all.requests ${constants.dev_TABLESAMPLE}
-WHERE date = '${two_months_ago}';
+WHERE date = '${constants.current_month}';
 
-CREATE OR REPLACE TABLE ${ctx.ref("all", "parsed_css")} AS
+CREATE TABLE IF NOT EXISTS ${ctx.ref("all", "parsed_css")} AS
 SELECT *
-FROM httparchive.all.parsed_css ${constants.dev_TABLESAMPLE}
-WHERE date = '${two_months_ago}';
+FROM httparchive.all.parsed_css
+WHERE date = '${constants.current_month}'
+  ${constants.dev_rank5000_filter};
 
-CREATE OR REPLACE TABLE ${ctx.ref("core_web_vitals", "technologies")} AS
+CREATE SCHEMA IF NOT EXISTS core_web_vitals_dev;
+
+CREATE TABLE IF NOT EXISTS ${ctx.ref("core_web_vitals", "technologies")} AS
 SELECT *
-FROM httparchive.core_web_vitals.technologies
-WHERE date = '${two_months_ago}'
+FROM httparchive.core_web_vitals.technologies ${constants.dev_TABLESAMPLE}
+WHERE date = '${past_month}';
+
+CREATE SCHEMA IF NOT EXISTS blink_features_dev;
+
+CREATE TABLE IF NOT EXISTS ${ctx.ref("blink_features", "usage")} AS
+SELECT *
+FROM httparchive.blink_features.usage ${constants.dev_TABLESAMPLE}
+WHERE yyyymmdd = '${past_month}';
+
+CREATE TABLE IF NOT EXISTS ${ctx.ref("blink_features", "features")} AS
+SELECT *
+FROM httparchive.blink_features.features ${constants.dev_TABLESAMPLE}
+WHERE yyyymmdd = DATE '${past_month}';
 `)

--- a/definitions/output/blink_features/features.js
+++ b/definitions/output/blink_features/features.js
@@ -1,0 +1,69 @@
+
+publish("features", {
+  schema: "blink_features",
+  type: "incremental",
+  protected: true,
+  bigquery: {
+    partitionBy: "yyyymmdd",
+    clusterBy: ["client", "rank"]
+  },
+  tags: ["blink_features_report"]
+}).preOps(ctx => `
+DELETE FROM ${ctx.self()}
+WHERE date = '${constants.current_month}';
+`).query(ctx => `
+CREATE TEMP FUNCTION features(payload STRING)
+RETURNS ARRAY<STRUCT<id STRING, name STRING, type STRING>> LANGUAGE js AS
+"""
+function getFeatureNames(featureMap, featureType) {
+  try {
+    return Object.entries(featureMap).map(([key, value]) => {
+      // After Feb 2020 keys are feature IDs.
+      if (value.name) {
+        return {'name': value.name, 'type': featureType, 'id': key};
+      }
+      // Prior to Feb 2020 keys fell back to IDs if the name was unknown.
+      if (idPattern.test(key)) {
+        return {'name': '', 'type': featureType, 'id': key.match(idPattern)[1]};
+      }
+      // Prior to Feb 2020 keys were names by default.
+      return {'name': key, 'type': featureType, 'id': ''};
+    });
+  } catch (e) {
+    return [];
+  }
+}
+
+var $ = JSON.parse(payload);
+if (!$._blinkFeatureFirstUsed) return [];
+
+var idPattern = new RegExp('^Feature_(\\d+)$');
+return getFeatureNames($._blinkFeatureFirstUsed.Features, 'default')
+  .concat(getFeatureNames($._blinkFeatureFirstUsed.CSSFeatures, 'css'))
+  .concat(getFeatureNames($._blinkFeatureFirstUsed.AnimatedCSSFeatures, 'animated-css'));
+""";
+
+SELECT
+  date AS yyyymmdd,
+  client,
+  url,
+  feature.feature AS feature,
+  feature.type,
+  feature.id,
+  rank
+FROM (
+  SELECT
+    date,
+    client,
+    page AS url,
+    payload,
+    rank,
+    feature
+  FROM
+    ${ctx.resolve("all", "pages")},
+    UNNEST(features) AS feature
+  WHERE
+    date = '${constants.current_month}' AND
+    is_root_page = TRUE
+)
+`)

--- a/definitions/output/blink_features/features.js
+++ b/definitions/output/blink_features/features.js
@@ -59,7 +59,7 @@ FROM (
     payload,
     rank,
     feature
-  FROM ${ctx.ref("all", "pages")},
+  FROM ${ctx.ref("all", "pages")} ${constants.dev_TABLESAMPLE},
     UNNEST(features) AS feature
   WHERE
     date = '${constants.current_month}' AND

--- a/definitions/output/blink_features/usage.js
+++ b/definitions/output/blink_features/usage.js
@@ -5,7 +5,7 @@ publish("usage", {
   tags: ["blink_features_report"]
 }).preOps(ctx => `
 DELETE FROM ${ctx.self()}
-WHERE date = '${constants.current_month}';
+WHERE yyyymmdd = '${constants.current_month}';
 `).query(ctx => `
 SELECT
   REGEXP_REPLACE(CAST(date AS STRING), '-', '') AS yyyymmdd,
@@ -26,7 +26,7 @@ FROM (
     type,
     COUNT(DISTINCT url) AS num_urls,
     ARRAY_AGG(url ORDER BY rank, url LIMIT 100) AS sample_urls
-  FROM ${ctx.resolve("blink_features", "features")}
+  FROM ${ctx.ref("blink_features", "features")} ${constants.dev_TABLESAMPLE}
   WHERE
     yyyymmdd = '${constants.current_month}'
   GROUP BY
@@ -41,10 +41,10 @@ JOIN (
     date,
     client,
     COUNT(DISTINCT page) AS total_urls
-  FROM ${ctx.resolve("all", "pages")}
+  FROM ${ctx.ref("all", "pages")}
   WHERE
     date = '${constants.current_month}' AND
-    is_root_page = TRUE
+    is_root_page = TRUE ${constants.dev_rank5000_filter}
   GROUP BY
     date,
     client

--- a/definitions/output/blink_features/usage.js
+++ b/definitions/output/blink_features/usage.js
@@ -1,0 +1,53 @@
+publish("usage", {
+  schema: "blink_features",
+  type: "incremental",
+  protected: true,
+  tags: ["blink_features_report"]
+}).preOps(ctx => `
+DELETE FROM ${ctx.self()}
+WHERE date = '${constants.current_month}';
+`).query(ctx => `
+SELECT
+  REGEXP_REPLACE(CAST(date AS STRING), '-', '') AS yyyymmdd,
+  client,
+  id,
+  feature,
+  type,
+  num_urls,
+  total_urls,
+  num_urls / total_urls AS pct_urls,
+  sample_urls
+FROM (
+  SELECT
+    yyyymmdd AS date,
+    client,
+    id,
+    feature,
+    type,
+    COUNT(DISTINCT url) AS num_urls,
+    ARRAY_AGG(url ORDER BY rank, url LIMIT 100) AS sample_urls
+  FROM ${ctx.resolve("blink_features", "features")}
+  WHERE
+    yyyymmdd = '${constants.current_month}'
+  GROUP BY
+    yyyymmdd,
+    client,
+    id,
+    feature,
+    type
+)
+JOIN (
+  SELECT
+    date,
+    client,
+    COUNT(DISTINCT page) AS total_urls
+  FROM ${ctx.resolve("all", "pages")}
+  WHERE
+    date = '${constants.current_month}' AND
+    is_root_page = TRUE
+  GROUP BY
+    date,
+    client
+)
+USING (date, client)
+`)

--- a/definitions/output/blink_features/usage.js
+++ b/definitions/output/blink_features/usage.js
@@ -5,10 +5,10 @@ publish("usage", {
   tags: ["blink_features_report"]
 }).preOps(ctx => `
 DELETE FROM ${ctx.self()}
-WHERE yyyymmdd = '${constants.current_month}';
+WHERE yyyymmdd = REPLACE('${constants.current_month}', '-', '');
 `).query(ctx => `
 SELECT
-  REGEXP_REPLACE(CAST(date AS STRING), '-', '') AS yyyymmdd,
+  REPLACE(CAST(date AS STRING), '-', '') AS yyyymmdd,
   client,
   id,
   feature,

--- a/definitions/output/sample_data/pages_10k.js
+++ b/definitions/output/sample_data/pages_10k.js
@@ -1,13 +1,13 @@
 publish("pages_10k", {
-    type: "table",
-    schema: "sample_data",
-    bigquery: {
-        partitionBy: "date",
-        clusterBy: ["client", "is_root_page", "rank"]
-    },
-    tags: ["crawl_results_all"]
+  type: "table",
+  schema: "sample_data",
+  bigquery: {
+    partitionBy: "date",
+    clusterBy: ["client", "is_root_page", "rank"]
+  },
+  tags: ["crawl_results_all"]
 }).preOps(ctx => `
-DROP TABLE ${ctx.self()};
+DROP TABLE IF EXISTS ${ctx.self()};
 `).query(ctx => `
 SELECT *
 FROM ${ctx.ref("all", "pages")}

--- a/definitions/output/sample_data/parsed_css_10k.js
+++ b/definitions/output/sample_data/parsed_css_10k.js
@@ -1,13 +1,13 @@
 publish("parsed_css_10k", {
-    type: "table",
-    schema: "sample_data",
-    bigquery: {
-        partitionBy: "date",
-        clusterBy: ["client", "is_root_page", "rank", "page"]
-    },
-    tags: ["crawl_results_all"]
+  type: "table",
+  schema: "sample_data",
+  bigquery: {
+    partitionBy: "date",
+    clusterBy: ["client", "is_root_page", "rank", "page"]
+  },
+  tags: ["crawl_results_all"]
 }).preOps(ctx => `
-DROP TABLE ${ctx.self()};
+DROP TABLE IF EXISTS ${ctx.self()};
 `).query(ctx => `
 SELECT *
 FROM ${ctx.ref("all", "parsed_css")}

--- a/definitions/output/sample_data/requests_10k.js
+++ b/definitions/output/sample_data/requests_10k.js
@@ -1,13 +1,13 @@
 publish("requests_10k", {
-    type: "table",
-    schema: "sample_data",
-        bigquery: {
-        partitionBy: "date",
-        clusterBy: ["client", "is_root_page", "is_main_document", "type"]
-    },
-    tags: ["crawl_results_all"]
+  type: "table",
+  schema: "sample_data",
+  bigquery: {
+    partitionBy: "date",
+    clusterBy: ["client", "is_root_page", "is_main_document", "type"]
+  },
+  tags: ["crawl_results_all"]
 }).preOps(ctx => `
-DROP TABLE ${ctx.self()};
+DROP TABLE IF EXISTS ${ctx.self()};
 `).query(ctx => `
 SELECT *
 FROM ${ctx.ref("all", "requests")}

--- a/definitions/output/summary_requests.js
+++ b/definitions/output/summary_requests.js
@@ -71,10 +71,10 @@ SELECT
 FROM ${ctx.ref("all", "requests")}
 WHERE
   date = '${constants.current_month}' AND
-  client = 'desktop' AND
+  client = '${client}' AND
   is_root_page AND
   summary IS NOT NULL AND
-  JSON_EXTRACT_SCALAR(METADATA, '$.page_id') IS NOT NULL AND
-  JSON_EXTRACT_SCALAR(METADATA, '$.page_id') != ''
+  JSON_EXTRACT_SCALAR(summary, '$.requestid') IS NOT NULL AND
+  JSON_EXTRACT_SCALAR(summary, '$.requestid') != ''
     `);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ FROM (
     action: "runDataformRepo",
     actionArgs: {
       repoName: "crawl-data",
-      tags: ["crawl_results_all", "crawl_results_legacy"]
+      tags: ["crawl_results_all", "blink_features_report", "crawl_results_legacy"]
     }
   }
 };


### PR DESCRIPTION
Removes delay between the crawl completion and reports availability.
Triggered by `crawl_complete` PubSub event.

Replaces scheduled queries: [materialize_blink_features](https://console.cloud.google.com/bigquery/scheduled-queries/locations/us/configs/5c406c6a-0000-204c-a802-94eb2c1a3c78/runs?authuser=7&project=httparchive) and [Materialize Blink Feature Percentages](https://console.cloud.google.com/bigquery/scheduled-queries/locations/us/configs/5c429020-0000-26d8-ac16-f40304365a6c/runs?authuser=7&project=httparchive)

- [x] `features`
- [x] `usage`

Closes https://github.com/HTTPArchive/data-pipeline/issues/177