### PR TITLE
Trim page ids from pages.metadata

### DIFF
--- a/definitions/output/all/reprocess_pages.js
+++ b/definitions/output/all/reprocess_pages.js
@@ -262,7 +262,12 @@ SELECT
   SAFE.PARSE_JSON(lighthouse, wide_number_mode => 'round') AS lighthouse,
   features,
   technologies,
-  SAFE.PARSE_JSON(metadata, wide_number_mode => 'round') AS metadata
+  JSON_REMOVE(
+    SAFE.PARSE_JSON(metadata, wide_number_mode => 'round'),
+    '$.page_id',
+    '$.parent_page_id',
+    '$.root_page_id'
+  ) AS metadata
 FROM \`all.pages\`
 WHERE
   date = "${iteration.month}" AND


### PR DESCRIPTION
Since we've removed IDs in requests data, let's check page_id's in `pages`.

Removed:
 - page_id
 - parent_page_id
 - root_page_id
from pages.metadata.

@pmeenan @tunetheweb if you're aware of cases where these are used, please comment.
Or approve otherwise.