### PR TITLE
Tech Report: Technologies total origins from crawl

### DIFF
--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -16,7 +16,9 @@ WITH pages AS (
   WHERE
     date = '${pastMonth}'
     ${constants.devRankFilter}
-), tech_origins AS (
+),
+
+tech_origins AS (
   SELECT
     client,
     technology,

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -9,7 +9,7 @@ publish('cwv_tech_technologies', {
 WITH pages AS (
   SELECT DISTINCT
     client,
-    root_page AS origin,
+    root_page,
     tech.technology
   FROM ${ctx.ref('crawl', 'pages')},
     UNNEST(technologies) AS tech
@@ -22,7 +22,7 @@ tech_origins AS (
   SELECT
     client,
     technology,
-    COUNT(origin) AS origins
+    COUNT(DISTINCT root_page) AS origins
   FROM pages
   GROUP BY
     client,
@@ -42,7 +42,7 @@ technologies AS (
 total_pages AS (
   SELECT
     client,
-    COUNT(DISTINCT origin) AS origins
+    COUNT(DISTINCT root_page) AS origins
   FROM pages
   GROUP BY client
 )
@@ -54,7 +54,7 @@ SELECT
   category,
   category_obj,
   similar_technologies,
-  COALESCE(origins, 0) AS origins
+  origins
 FROM tech_origins
 INNER JOIN technologies
 USING(technology)
@@ -75,5 +75,5 @@ CROSS JOIN (
     ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category) AS categories
   FROM technologies,
     UNNEST(category_obj) AS category
-) AS cat
+)
 `)

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -27,7 +27,7 @@ WITH pages AS (
     technology
 ), technologies AS (
   SELECT
-    technology,
+    name AS technology,
     description,
     ARRAY_TO_STRING(categories, ', ') AS category,
     categories AS category_obj,
@@ -52,7 +52,6 @@ SELECT
 FROM tech_origins
 INNER JOIN technologies
 USING(technology)
-ORDER BY origins DESC
 
 UNION ALL
 

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -65,15 +65,9 @@ SELECT
   client,
   'ALL' AS technology,
   NULL AS description,
-  ARRAY_TO_STRING(categories, ', ') AS category,
-  categories AS category_obj,
+  NULL AS category,
+  NULL AS category_obj,
   NULL AS similar_technologies,
   origins
 FROM total_pages
-CROSS JOIN (
-  SELECT
-    ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category) AS categories
-  FROM technologies,
-    UNNEST(category_obj) AS category
-)
 `)

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -33,7 +33,9 @@ WITH pages AS (
     categories AS category_obj,
     NULL AS similar_technologies
   FROM ${ctx.ref('wappalyzer', 'apps')}
-), total_pages AS (
+),
+
+total_pages AS (
   SELECT
     client,
     COUNT(DISTINCT origin) AS origins

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -33,10 +33,15 @@ technologies AS (
   SELECT
     name AS technology,
     description,
-    ARRAY_TO_STRING(categories, ', ') AS category,
+    STRING_AGG(DISTINCT category, ', ' ORDER BY category ASC) AS category,
     categories AS category_obj,
     NULL AS similar_technologies
-  FROM ${ctx.ref('wappalyzer', 'apps')}
+  FROM ${ctx.ref('wappalyzer', 'apps')},
+    UNNEST(categories) AS category
+  GROUP BY
+    technology,
+    description,
+    categories
 ),
 
 total_pages AS (

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -25,7 +25,9 @@ WITH pages AS (
   GROUP BY
     client,
     technology
-), technologies AS (
+),
+
+technologies AS (
   SELECT
     name AS technology,
     description,

--- a/definitions/output/reports/cwv_tech_technologies.js
+++ b/definitions/output/reports/cwv_tech_technologies.js
@@ -6,19 +6,69 @@ publish('cwv_tech_technologies', {
   tags: ['crux_ready']
 }).query(ctx => `
 /* {"dataform_trigger": "report_cwv_tech_complete", "name": "technologies", "type": "dict"} */
+WITH pages AS (
+  SELECT DISTINCT
+    client,
+    root_page AS origin,
+    tech.technology
+  FROM ${ctx.ref('crawl', 'pages')},
+    UNNEST(technologies) AS tech
+  WHERE
+    date = '${pastMonth}'
+    ${constants.devRankFilter}
+), tech_origins AS (
+  SELECT
+    client,
+    technology,
+    COUNT(origin) AS origins
+  FROM pages
+  GROUP BY
+    client,
+    technology
+), technologies AS (
+  SELECT
+    technology,
+    description,
+    ARRAY_TO_STRING(categories, ', ') AS category,
+    categories AS category_obj,
+    NULL AS similar_technologies
+  FROM ${ctx.ref('wappalyzer', 'apps')}
+), total_pages AS (
+  SELECT
+    client,
+    COUNT(DISTINCT origin) AS origins
+  FROM pages
+  GROUP BY client
+)
+
 SELECT
   client,
-  app AS technology,
+  technology,
   description,
   category,
-  SPLIT(category, ",") AS category_obj,
+  category_obj,
+  similar_technologies,
+  COALESCE(origins, 0) AS origins
+FROM tech_origins
+INNER JOIN technologies
+USING(technology)
+ORDER BY origins DESC
+
+UNION ALL
+
+SELECT
+  client,
+  'ALL' AS technology,
+  NULL AS description,
+  ARRAY_TO_STRING(categories, ', ') AS category,
+  categories AS category_obj,
   NULL AS similar_technologies,
   origins
-FROM ${ctx.ref('core_web_vitals', 'technologies')}
-LEFT JOIN ${ctx.ref('wappalyzer', 'apps')}
-ON app = name
-WHERE date = '${pastMonth}' AND
-  geo = 'ALL' AND
-  rank = 'ALL'
-ORDER BY origins DESC
+FROM total_pages
+CROSS JOIN (
+  SELECT
+    ARRAY_AGG(DISTINCT category IGNORE NULLS ORDER BY category) AS categories
+  FROM technologies,
+    UNNEST(category_obj) AS category
+) AS cat
 `)


### PR DESCRIPTION
Previously we used metric from `core_web_vitals.technologies` table, calculated as `CrUX INNER JOIN crawl`.
Now using full adoption from `crawl.pages`.