### PR TITLE
Moving sample tables and latest views to crawl dataset

### DIFF
--- a/definitions/output/crawl/pages_10k.js
+++ b/definitions/output/crawl/pages_10k.js
@@ -1,14 +1,14 @@
-publish('parsed_css_10k', {
+publish('pages_10k', {
   type: 'table',
-  schema: 'sample_data',
+  schema: 'crawl',
   bigquery: {
     partitionBy: 'date',
-    clusterBy: ['client', 'is_root_page', 'rank', 'page']
+    clusterBy: ['client', 'is_root_page', 'rank']
   },
   tags: ['crawl_complete']
 }).query(ctx => `
 SELECT *
-FROM ${ctx.ref('crawl', 'parsed_css')}
+FROM ${ctx.ref('crawl', 'pages')}
 WHERE date = '${constants.currentMonth}' AND
     rank <= 10000
 `)

--- a/definitions/output/crawl/pages_latest.js
+++ b/definitions/output/crawl/pages_latest.js
@@ -1,0 +1,17 @@
+publish('pages_latest', {
+  type: 'view',
+  schema: 'crawl'
+}).query(ctx => `
+SELECT
+  *
+FROM ${ctx.ref('crawl', 'pages')}
+WHERE
+  date IS NOT NULL AND
+  date = (
+    SELECT
+      CAST(REGEXP_REPLACE(MAX(IF(partition_id = '__NULL__', NULL, partition_id)), r'(\\d{4})(\\d{2})(\\d{2})', '\\\\1-\\\\2-\\\\3') AS DATE) AS date
+    FROM crawl.INFORMATION_SCHEMA.PARTITIONS
+    WHERE
+      table_name = 'pages' AND
+      partition_id != '__NULL__')
+`)

--- a/definitions/output/crawl/parsed_css_10k.js
+++ b/definitions/output/crawl/parsed_css_10k.js
@@ -1,14 +1,14 @@
-publish('pages_10k', {
+publish('parsed_css_10k', {
   type: 'table',
-  schema: 'sample_data',
+  schema: 'crawl',
   bigquery: {
     partitionBy: 'date',
-    clusterBy: ['client', 'is_root_page', 'rank']
+    clusterBy: ['client', 'is_root_page', 'rank', 'page']
   },
   tags: ['crawl_complete']
 }).query(ctx => `
 SELECT *
-FROM ${ctx.ref('crawl', 'pages')}
+FROM ${ctx.ref('crawl', 'parsed_css')}
 WHERE date = '${constants.currentMonth}' AND
     rank <= 10000
 `)

--- a/definitions/output/crawl/requests_10k.js
+++ b/definitions/output/crawl/requests_10k.js
@@ -1,6 +1,6 @@
 publish('requests_10k', {
   type: 'table',
-  schema: 'sample_data',
+  schema: 'crawl',
   bigquery: {
     partitionBy: 'date',
     clusterBy: ['client', 'is_root_page', 'is_main_document', 'type']

--- a/definitions/output/crawl/requests_latest.js
+++ b/definitions/output/crawl/requests_latest.js
@@ -1,0 +1,17 @@
+publish('requests_latest', {
+  type: 'view',
+  schema: 'crawl'
+}).query(ctx => `
+SELECT
+  *
+FROM ${ctx.ref('crawl', 'requests')}
+WHERE
+  date IS NOT NULL AND
+  date = (
+    SELECT
+      CAST(REGEXP_REPLACE(MAX(IF(partition_id = '__NULL__', NULL, partition_id)), r'(\\d{4})(\\d{2})(\\d{2})', '\\\\1-\\\\2-\\\\3') AS DATE) AS date
+    FROM crawl.INFORMATION_SCHEMA.PARTITIONS
+    WHERE
+      table_name = 'requests' AND
+      partition_id != '__NULL__')
+`)


### PR DESCRIPTION
It's gonna be faster to switch between and easier to find out about these two additional representations if they are located in the main dataset.

By switching I mean changing just the table name (and keep the dataset).

I think it makes sense to also consider the order:

current:
- pages_10k
- pages_latest
- pages
- parsed_css_10k
- parsed_css
- requests_10k
- requests_latest
- requests

optional:
- 10k_sample_pages
- 10k_sample_parsed_css
- 10k_sample_requests
- latest_pages
- latest_requests
- pages
- parsed_css
- requests