### PR TITLE
🧪 test(dataform-service): add tests for runWorkflow and getCompilationResults

### DIFF
--- a/infra/dataform-service/src/dataform.test.js
+++ b/infra/dataform-service/src/dataform.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { DataformClient } from '@google-cloud/dataform'
+import { getCompilationResults, runWorkflow } from './dataform.js'
+
+test('getCompilationResults', async (t) => {
+  const mockResponse = [{ name: 'mock-compilation-result-name' }]
+  t.mock.method(DataformClient.prototype, 'createCompilationResult', async () => mockResponse)
+
+  const repoURI = 'mock-repo-uri'
+  const result = await getCompilationResults(repoURI)
+
+  assert.strictEqual(result, 'mock-compilation-result-name')
+
+  const calls = DataformClient.prototype.createCompilationResult.mock.calls
+  assert.strictEqual(calls.length, 1)
+  assert.deepStrictEqual(calls[0].arguments[0], {
+    parent: repoURI,
+    compilationResult: {
+      releaseConfig: `${repoURI}/releaseConfigs/production`
+    }
+  })
+})
+
+test('runWorkflow', async (t) => {
+  const mockResponse = [{ name: 'mock-workflow-invocation-name' }]
+  t.mock.method(DataformClient.prototype, 'createWorkflowInvocation', async () => mockResponse)
+
+  const repoURI = 'mock-repo-uri'
+  const compilationResult = 'mock-compilation-result-name'
+  const tags = ['tag1', 'tag2']
+
+  await runWorkflow(repoURI, compilationResult, tags)
+
+  const calls = DataformClient.prototype.createWorkflowInvocation.mock.calls
+  assert.strictEqual(calls.length, 1)
+  assert.deepStrictEqual(calls[0].arguments[0], {
+    parent: repoURI,
+    workflowInvocation: {
+      compilationResult,
+      invocationConfig: {
+        includedTags: tags,
+        fullyRefreshIncrementalTablesEnabled: false,
+        transitiveDependenciesIncluded: false,
+        transitiveDependentsIncluded: false
+      }
+    }
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for `runWorkflow` inside `infra/dataform-service/src/dataform.js`.
📊 **Coverage:** Covered both `runWorkflow` and `getCompilationResults` to ensure `DataformClient` wrapper correctly passes the requested configs and extracts responses.
✨ **Result:** Test coverage for `dataform.js` increased substantially by properly mocking Dataform APIs, reducing the risk of regressions on these core Dataform trigger functionalities.

---
*PR created automatically by Jules for task [3325976520998964703](https://jules.google.com/task/3325976520998964703) started by @max-ostapenko*