### PR TITLE
🧹 Remove commented-out break statements in timeseries_storage_sync.js

### DIFF
--- a/script/timeseries_storage_sync.js
+++ b/script/timeseries_storage_sync.js
@@ -232,9 +232,7 @@ async function importHistogramData() {
           continue
         }
       }
-      //break // TEMP: only do first metric
     }
-    //break // TEMP: only do first lens
   }
 }
 


### PR DESCRIPTION
🎯 **What:** Removed two commented-out `break` statements in `script/timeseries_storage_sync.js`.
💡 **Why:** Improves code cleanliness and maintainability by removing dead code that was likely used for temporary debugging.
✅ **Verification:** Verified script syntax with `node -c script/timeseries_storage_sync.js`.
✨ **Result:** A cleaner script without misleading commented-out control flow statements.

---
*PR created automatically by Jules for task [10253376808696861043](https://jules.google.com/task/10253376808696861043) started by @max-ostapenko*