### PR TITLE
🧹 Remove metrics whitelist after migration

### DIFF
--- a/definitions/output/reports/reports_dynamic.js
+++ b/definitions/output/reports/reports_dynamic.js
@@ -136,10 +136,8 @@ function generateReportConfigurations() {
     date >= DATE_RANGE.startDate;
     date = constants.fnPastMonth(date)) {
 
-    const whitelistedMetrics = availableMetrics.filter(metric => !metric.disabled)
-
     // For each available metric
-    whitelistedMetrics.forEach(metric => {
+    availableMetrics.forEach(metric => {
       // For each SQL type (histogram, timeseries)
       metric.SQL.forEach(sql => {
         // For each available lens (all, top1k, wordpress, etc.)


### PR DESCRIPTION
🧹 What: Removed the `whitelistedMetrics` filter that filtered available metrics by `!metric.disabled` during migration.
💡 Why: The migration is complete, so reports are no longer limited to whitelisted/enabled metrics.
✅ Verification: Ran `node -c definitions/output/reports/reports_dynamic.js` to ensure valid syntax.
✨ Result: `availableMetrics` are iterated over directly.

---
*PR created automatically by Jules for task [7327008346596630847](https://jules.google.com/task/7327008346596630847) started by @max-ostapenko*